### PR TITLE
Fixed load with command line arguments

### DIFF
--- a/server/daemon.go
+++ b/server/daemon.go
@@ -81,12 +81,13 @@ func main() {
 	}
 
 	config := gold.NewServerConfig()
-	confLoaded := true
+	confLoaded := false
 	if len(*conf) > 0 {
 		err = config.LoadJSONFile(*conf)
-		if err != nil {
+		if err == nil {
+			confLoaded = true
+		} else {
 			log.Println(err)
-			confLoaded = false
 		}
 	}
 	if !confLoaded {


### PR DESCRIPTION
I think there is a bug that means the server will only run with a config file, but not command line arguments.  

Im slightly new to go and could not find a test for this,  But I've run the test suite and I think it passes

Would be great if it could be quickly checked before merging.

    go test -cover -v .
    === RUN TestACLInit
    --- PASS: TestACLInit (1.06s)
    === RUN TestACLEmpty
    --- PASS: TestACLEmpty (0.02s)
    === RUN TestACLOrigin
    --- PASS: TestACLOrigin (0.06s)
    === RUN TestACLOwnerOnly
    --- PASS: TestACLOwnerOnly (0.15s)
    === RUN TestACLReadOnly
    --- PASS: TestACLReadOnly (0.11s)
    === RUN TestACLAppendOnly
    --- PASS: TestACLAppendOnly (0.08s)
    === RUN TestACLRestricted
    --- PASS: TestACLRestricted (0.07s)
    === RUN TestACLGroup
    --- PASS: TestACLGroup (0.10s)
    === RUN TestACLDefaultForNew
    --- PASS: TestACLDefaultForNew (0.06s)
    === RUN TestACLWebIDDelegation
    --- PASS: TestACLWebIDDelegation (0.04s)
    === RUN TestACLCleanUp
    --- PASS: TestACLCleanUp (0.02s)
    === RUN TestParseDigestAuthorizationHeader
    --- PASS: TestParseDigestAuthorizationHeader (0.00s)
    === RUN TestParseDigestAuthenticateHeader
    --- PASS: TestParseDigestAuthenticateHeader (0.00s)
    === RUN TestCookieAuth
    --- PASS: TestCookieAuth (0.03s)
    === RUN TestWebIDRSAAuth
    --- PASS: TestWebIDRSAAuth (0.12s)
    === RUN TestCleanupAuth
    --- PASS: TestCleanupAuth (0.02s)
    === RUN TestACLCleanUsers
    --- PASS: TestACLCleanUsers (0.01s)
    === RUN TestNegotiatePicturesOfWebPages
    --- PASS: TestNegotiatePicturesOfWebPages (0.00s)
    === RUN TestNegotiateFirstMatch
    --- PASS: TestNegotiateFirstMatch (0.00s)
    === RUN TestNegotiateSecondMatch
    --- PASS: TestNegotiateSecondMatch (0.00s)
    === RUN TestNegotiateWildcardMatch
    --- PASS: TestNegotiateWildcardMatch (0.00s)
    === RUN TestNegotiateInvalidMediaRange
    --- PASS: TestNegotiateInvalidMediaRange (0.00s)
    === RUN TestNegotiateInvalidParam
    --- PASS: TestNegotiateInvalidParam (0.00s)
    === RUN TestNegotiateEmptyAccept
    --- PASS: TestNegotiateEmptyAccept (0.00s)
    === RUN TestNegotiateStarAccept
    --- PASS: TestNegotiateStarAccept (0.00s)
    === RUN TestNegotiateNoAlternative
    --- PASS: TestNegotiateNoAlternative (0.00s)
    === RUN TestSignAndVerify
    --- PASS: TestSignAndVerify (0.03s)
    === RUN TestJSONTerm2Term
    --- PASS: TestJSONTerm2Term (0.00s)
    === RUN TestParseJSONLD
    --- PASS: TestParseJSONLD (0.00s)
    === RUN TestSerializeJSONLD
    --- PASS: TestSerializeJSONLD (0.00s)
    === RUN TestGraphPatch
    --- PASS: TestGraphPatch (0.00s)
    === RUN TestGraphOne
    --- PASS: TestGraphOne (0.00s)
    === RUN TestGraphAll
    --- PASS: TestGraphAll (0.00s)
    === RUN TestLinkHeaderParser
    --- PASS: TestLinkHeaderParser (0.00s)
    === RUN TestPreferHeaderParser
    --- PASS: TestPreferHeaderParser (0.00s)
    === RUN TestNewUUID
    --- PASS: TestNewUUID (0.00s)
    === RUN TestMimeParserExpect
    --- PASS: TestMimeParserExpect (0.00s)
    === RUN TestMimeSerializerExpect
    --- PASS: TestMimeSerializerExpect (0.00s)
    === RUN TestPathInfo
    --- PASS: TestPathInfo (0.00s)
    === RUN TestProxy
    --- PASS: TestProxy (0.23s)
    === RUN TestRDFBrack
    --- PASS: TestRDFBrack (0.00s)
    === RUN TestRDFDebrack
    --- PASS: TestRDFDebrack (0.00s)
    === RUN TestDefrag
    --- PASS: TestDefrag (0.00s)
    === RUN TestMKCOL
    --- PASS: TestMKCOL (0.01s)
    === RUN TestSkin
    --- PASS: TestSkin (0.35s)
    === RUN TestRedirectSignUpWithVhosts
    --- PASS: TestRedirectSignUpWithVhosts (0.41s)
    === RUN TestWebContent
    --- PASS: TestWebContent (0.04s)
    === RUN TestHTMLIndex
    --- PASS: TestHTMLIndex (0.00s)
    === RUN TestOPTIONS
    --- PASS: TestOPTIONS (0.00s)
    === RUN TestOPTIONSOrigin
    --- PASS: TestOPTIONSOrigin (0.00s)
    === RUN TestURIwithSpaces
    --- PASS: TestURIwithSpaces (0.01s)
    === RUN TestURIwithWeirdChars
    --- PASS: TestURIwithWeirdChars (0.01s)
    === RUN TestLDPPUTContainer
    --- PASS: TestLDPPUTContainer (0.01s)
    === RUN TestLDPPostLDPC
    --- PASS: TestLDPPostLDPC (0.02s)
    === RUN TestLDPPostLDPRWithSlug
    --- PASS: TestLDPPostLDPRWithSlug (0.02s)
    === RUN TestLDPPostLDPRNoSlug
    --- PASS: TestLDPPostLDPRNoSlug (0.01s)
    === RUN TestLDPGetLDPC
    --- PASS: TestLDPGetLDPC (0.00s)
    === RUN TestLDPPreferContainmentHeader
    --- PASS: TestLDPPreferContainmentHeader (0.01s)
    === RUN TestLDPPreferEmptyHeader
    --- PASS: TestLDPPreferEmptyHeader (0.01s)
    === RUN TestLDPLinkHeaders
    --- PASS: TestLDPLinkHeaders (0.04s)
    === RUN TestStreaming
    --- PASS: TestStreaming (0.03s)
    === RUN TestPOSTSPARQL
    --- PASS: TestPOSTSPARQL (0.01s)
    === RUN TestPOSTTurtle
    --- PASS: TestPOSTTurtle (0.02s)
    === RUN TestPATCHJson
    --- PASS: TestPATCHJson (0.01s)
    === RUN TestPATCHSPARQL
    --- PASS: TestPATCHSPARQL (0.01s)
    === RUN TestPATCHFailParse
    --- PASS: TestPATCHFailParse (0.01s)
    === RUN TestPUTTurtle
    --- PASS: TestPUTTurtle (0.01s)
    === RUN TestHEAD
    --- PASS: TestHEAD (0.01s)
    === RUN TestHEADUnsupportedMediaType
    --- PASS: TestHEADUnsupportedMediaType (0.01s)
    === RUN TestOPTIONSUnsupportedMediaType
    --- PASS: TestOPTIONSUnsupportedMediaType (0.00s)
    === RUN TestGetUnsupportedMediaType
    --- PASS: TestGetUnsupportedMediaType (0.00s)
    === RUN TestAcceptHeaderWildcard
    --- PASS: TestAcceptHeaderWildcard (0.00s)
    === RUN TestCTypeServeDefault
    --- PASS: TestCTypeServeDefault (0.01s)
    === RUN TestCTypeFailForXHTMLXML
    --- PASS: TestCTypeFailForXHTMLXML (0.01s)
    === RUN TestIfMatch
    --- PASS: TestIfMatch (0.04s)
    === RUN TestIfNoneMatch
    --- PASS: TestIfNoneMatch (0.05s)
    === RUN TestGetJsonLd
    --- PASS: TestGetJsonLd (0.01s)
    === RUN TestPOSTForm
    --- PASS: TestPOSTForm (0.00s)
    === RUN TestPOSTMultiForm
    --- PASS: TestPOSTMultiForm (0.01s)
    === RUN TestLISTDIR
    --- PASS: TestLISTDIR (0.01s)
    === RUN TestGlob
    --- PASS: TestGlob (0.03s)
    === RUN TestDELETEFiles
    --- PASS: TestDELETEFiles (0.00s)
    === RUN TestDELETEFolders
    --- PASS: TestDELETEFolders (0.00s)
    === RUN TestInvalidMethod
    --- PASS: TestInvalidMethod (0.00s)
    === RUN TestInvalidAccept
    --- PASS: TestInvalidAccept (0.00s)
    === RUN TestInvalidContent
    --- PASS: TestInvalidContent (0.00s)
    === RUN TestRawContent
    --- PASS: TestRawContent (0.01s)
    === RUN TestStartFakeSMTPServer
    === RUN TestStartFakeSecureSMTPServer
    === RUN TestFakeSMTPDial
    === RUN TestFakeSMTPSecureDial
    === RUN TestSPARQLInsert
    --- PASS: TestSPARQLInsert (0.00s)
    === RUN TestSPARQLInsertDeleteUri
    --- PASS: TestSPARQLInsertDeleteUri (0.00s)
    === RUN TestSPARQLInsertDeleteLiteral
    --- PASS: TestSPARQLInsertDeleteLiteral (0.00s)
    === RUN TestSPARQLInsertDeleteLiteralWithDataType
    --- PASS: TestSPARQLInsertDeleteLiteralWithDataType (0.00s)
    === RUN TestParseSPKAC
    --- PASS: TestParseSPKAC (0.00s)
    === RUN TestCreateCertificateFromSPKAC
    --- PASS: TestCreateCertificateFromSPKAC (0.03s)
    === RUN TestNewAccountWithoutVhosts
    --- PASS: TestNewAccountWithoutVhosts (0.01s)
    === RUN TestNewAccountWithVhosts
    --- PASS: TestNewAccountWithVhosts (0.01s)
    === RUN TestNewCertWithSPKAC
    --- PASS: TestNewCertWithSPKAC (0.18s)
    === RUN TestNewAccountWithSPKAC
    --- PASS: TestNewAccountWithSPKAC (0.11s)
    === RUN TestAccountRecoveryForm
    --- PASS: TestAccountRecoveryForm (0.00s)
    === RUN TestAccountRecovery
    --- PASS: TestAccountRecovery (0.12s)
    === RUN TestAccountRecoverySecureSMTP
    --- PASS: TestAccountRecoverySecureSMTP (0.08s)
    === RUN TestAccountStatusWithoutVhosts
    --- PASS: TestAccountStatusWithoutVhosts (0.02s)
    === RUN TestAccountStatusWithVhosts
    --- PASS: TestAccountStatusWithVhosts (0.01s)
    === RUN TestAccountInfo
    --- PASS: TestAccountInfo (0.01s)
    === RUN TestLiteralEqual
    --- PASS: TestLiteralEqual (0.00s)
    === RUN TestNewLiteralWithLanguage
    --- PASS: TestNewLiteralWithLanguage (0.00s)
    === RUN TestNewLiteralWithDatatype
    --- PASS: TestNewLiteralWithDatatype (0.00s)
    === RUN TestNewLiteralWithLanguageAndDatatype
    --- PASS: TestNewLiteralWithLanguageAndDatatype (0.00s)
    === RUN TestNewBlankNode
    --- PASS: TestNewBlankNode (0.00s)
    === RUN TestNewAnonNode
    --- PASS: TestNewAnonNode (0.00s)
    === RUN TestBNodeEqual
    --- PASS: TestBNodeEqual (0.00s)
    === RUN TestTripleEquals
    --- PASS: TestTripleEquals (0.00s)
    === RUN TestWebIDTLSauth
    --- PASS: TestWebIDTLSauth (0.25s)
    === RUN TestNewWebIDProfileWithKeys
    --- PASS: TestNewWebIDProfileWithKeys (0.12s)
    === RUN TestWebSocketPing
    --- PASS: TestWebSocketPing (0.01s)
    === RUN TestWebSocketSubPub
    --- PASS: TestWebSocketSubPub (0.02s)
    --- PASS: TestStartFakeSMTPServer (0.00s)
    --- PASS: TestStartFakeSecureSMTPServer (0.00s)
    --- PASS: TestFakeSMTPDial (0.20s)
    --- PASS: TestFakeSMTPSecureDial (0.21s)
    PASS
    coverage: 83.3% of statements