### PR TITLE
Do not declare pointless /config VOLUME

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN \
 
 EXPOSE 443
 EXPOSE 80
-VOLUME ["/data", "/config"]
-ADD gold.conf-example /tmp/
-RUN mv /tmp/gold.conf-example /config/
-CMD ["server", "-conf=/config/gold.conf", "-https=:443","-http=:80", "-root=/data/", "-debug"]
+VOLUME ["/data"]
+
+CMD ["server", "-https=:443", "-http=:80", "-root=/data/", "-debug"]


### PR DESCRIPTION
From [dockerfile docs on volumes](https://docs.docker.com/engine/reference/builder/#volume):
> Note: If any build steps change the data within the volume after it has been declared, those changes will be discarded.

This is exactly what is happening right now. Gold configuration is copied to /config directory and then /config volume is declared, which empties the /config directory. A valid alternative solution is to switch the order and add /config/gold.conf **before** the volume is declared but then the current gold.conf-example has to be changed because otherwise we'll get this error:
```bash
docker run --rm gold-local
2016/02/06 19:35:59 daemon.go:175: open /Users/user/certs/cert.pem: no such file or directory
```

This is why I propose getting rid of /config volume altogether and running the server with default parameters (as it's been done until now anyway, because /config/gold.conf did not exist in the image).