### PR TITLE
Add "Vary: Origin" to prevent caching CORS origin header

### DIFF
--- a/cors_test.go
+++ b/cors_test.go
@@ -1,0 +1,37 @@
+package gold
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCORSRequestHasOrigin(t *testing.T) {
+	requestOrigin := "https://example.com"
+	url := testServer.URL + "/_test/user1"
+	req, err := http.NewRequest("GET", url, nil)
+	assert.NoError(t, err)
+	req.Header.Set("Origin", requestOrigin)
+	resp, err := httpClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, requestOrigin, resp.Header.Get("Access-Control-Allow-Origin"))
+}
+
+func TestCORSRequestHasNoOrigin(t *testing.T) {
+	url := testServer.URL + "/_test/user1"
+	req, err := http.NewRequest("GET", url, nil)
+	assert.NoError(t, err)
+	resp, err := httpClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+}
+
+func TestVaryHeader(t *testing.T) {
+	url := testServer.URL + "/_test/user1"
+	req, err := http.NewRequest("GET", url, nil)
+	assert.NoError(t, err)
+	resp, err := httpClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, "Origin", resp.Header.Get("Vary"))
+}

--- a/server.go
+++ b/server.go
@@ -309,6 +309,7 @@ func (s *Server) handle(w http.ResponseWriter, req *httpRequest) (r *response) {
 	w.Header().Set("Accept-Patch", "application/json, application/sparql-update")
 	w.Header().Set("Accept-Post", "text/turtle, application/json")
 	w.Header().Set("Allow", strings.Join(methodsAll, ", "))
+	w.Header().Set("Vary", "Origin")
 
 	switch req.Method {
 	case "OPTIONS":


### PR DESCRIPTION
This should address #78 

I was hoping to run these CORS tests on all of the applicable HTTP methods. I had a helper function which would run them in such a way, but other tests in the suite failed due to resources being deleted/mutated with the mutative HTTP methods. Tests should ideally not share state, but I don't know enough about how the test server is set up to fix this. Once @deiu is back, we can figure it out.