### PR TITLE
Use ldp:inbox instead of solid:inbox for NewWebIDProfile creation

### DIFF
--- a/webid.go
+++ b/webid.go
@@ -374,7 +374,7 @@ func NewWebIDProfile(account webidAccount) *Graph {
 	g.AddTriple(userTerm, ns.space.Get("preferencesFile"), NewResource(account.PrefURI))
 	g.AddTriple(userTerm, ns.st.Get("privateTypeIndex"), NewResource(account.PrivTypeIndex))
 	g.AddTriple(userTerm, ns.st.Get("publicTypeIndex"), NewResource(account.PubTypeIndex))
-	g.AddTriple(userTerm, ns.st.Get("inbox"), NewResource(account.BaseURI+"/Inbox/"))
+	g.AddTriple(userTerm, ns.ldp.Get("inbox"), NewResource(account.BaseURI+"/Inbox/"))
 	g.AddTriple(userTerm, ns.st.Get("timeline"), NewResource(account.BaseURI+"/Timeline/"))
 
 	// add proxy and query endpoints


### PR DESCRIPTION
`ldp:inbox` (http://www.w3.org/ns/ldp#inbox with "stable" status) has its origins in `solid:inbox`, described as part of the LDN spec: https://www.w3.org/TR/ldn/ and has usage in the wild: https://linkedresearch.org/ldn/tests/summary . I suggest using it going forward.